### PR TITLE
Eliminate SBCL compilation warning

### DIFF
--- a/disjoint-sets.lisp
+++ b/disjoint-sets.lisp
@@ -11,12 +11,7 @@ Said otherwise: a set is identified by the id of its root set.
 
 |#
 
-(cl:in-package #:cl-user)
-
-(defpackage #:disjoint-sets
-  (:use #:cl))
-
-(in-package #:disjoint-sets)
+(cl:in-package #:disjoint-sets)
 
 (defun make-disjoint-sets (&optional number-of-sets)
   "Create a set of sets represented as an array.


### PR DESCRIPTION
SBCL is not happy about the package redefinition. Since the system is probably always loaded by ASDF, it is redundant to also redefine the package in the source file.