### PR TITLE
New convenience function COPY-DISJOINT-SETS

### DIFF
--- a/disjoint-sets.lisp
+++ b/disjoint-sets.lisp
@@ -75,6 +75,20 @@ Example:
         (root2 (disjoint-sets-find sets id2)))
     (setf (aref sets root2) root1)))
 
+(defun copy-disjoint-sets (sets)
+  "Copy a set of sets into a fresh array.
+
+Exmaple:
+(let* ((sets (make-disjoint-sets 2))
+       (copy (copy-disjoint-sets sets)))
+  (disjoint-sets-unify sets 0 1)
+  (values sets copy))
+=> #(0 0), #(0 1)
+"
+  (make-array (length sets) :element-type 'integer
+                            :adjustable t :fill-pointer t
+                            :initial-contents sets))
+
 (defun disjoint-sets-same-set-p (sets id1 id2)
   "Test if 2 items are in the same set.
 

--- a/disjoint-sets.lisp
+++ b/disjoint-sets.lisp
@@ -11,12 +11,7 @@ Said otherwise: a set is identified by the id of its root set.
 
 |#
 
-(cl:in-package #:cl-user)
-
-(defpackage #:disjoint-sets
-  (:use #:cl))
-
-(in-package #:disjoint-sets)
+(cl:in-package #:disjoint-sets)
 
 (defun make-disjoint-sets (&optional number-of-sets)
   "Create a set of sets represented as an array.


### PR DESCRIPTION
If someone uses these in backtracking algorithms, then it can be useful to keep a copy of the sets for reverting changes.

Note that this Pull Request also includes #1