### PR TITLE
Slight rewrite and breaking change

### DIFF
--- a/disjoint-sets.lisp
+++ b/disjoint-sets.lisp
@@ -13,7 +13,7 @@ Said otherwise: a set is identified by the id of its root set.
 
 (cl:in-package #:disjoint-sets)
 
-(defun make-disjoint-sets (&optional number-of-sets)
+(defun make-disjoint-sets (&optional (arity 0))
   "Create a set of sets represented as an array.
 
 Examples:
@@ -23,17 +23,12 @@ Examples:
 (make-disjoint-sets 10)
 ;; => #(0 1 2 3 4 5 6 7 8 9)
 "
-  (let ((sets (make-array (list (or number-of-sets 0))
-                          :element-type 'integer
-                          :adjustable t
-                          :fill-pointer t)))
-    (when number-of-sets
-      (loop :for i :below number-of-sets
-            :do (setf (aref sets i) i)))
-    sets))
+  (let ((sets (make-array `(,arity) :element-type 'integer
+                          :adjustable t :fill-pointer t)))
+    (dotimes (i arity sets) (setf (aref sets i) i))))
 
 (defun disjoint-sets-add (sets)
-  "Add a new item into its own disjoint set. Return a new id.
+  "Add a new item into its own disjoint set. Return the new id.
 
 Example:
 

--- a/disjoint-sets.lisp
+++ b/disjoint-sets.lisp
@@ -7,7 +7,7 @@ https://en.wikipedia.org/wiki/Disjoint-set_data_structure
 - A set that has itself as a parent is called a root.
 - The root of a set is the representative of that set.
 Said otherwise: a set is identified by the id of its root set.
-- Sets are merged with the "union" operation.
+- Sets are merged with the "join" operation.
 
 |#
 
@@ -58,13 +58,13 @@ Example:
             (setf (aref sets id) root))
           root))))
 
-(defun disjoint-sets-union (sets id1 id2)
+(defun disjoint-sets-join (sets id1 id2)
   "Merge two disjoint sets. Return the set representative (the root)
 
 Example:
 
-(disjoint-sets-union sets 1 2)
-=> 4 ; SETS is modified.
+(disjoint-sets-join sets 1 2)
+=> 4 ; `sets' is modified.
 "
   (let ((root1 (disjoint-sets-find sets id1))
         (root2 (disjoint-sets-find sets id2)))
@@ -76,7 +76,7 @@ Example:
 Exmaple:
 (let* ((sets (make-disjoint-sets 2))
        (copy (copy-disjoint-sets sets)))
-  (disjoint-sets-unify sets 0 1)
+  (disjoint-sets-join sets 0 1)
   (values sets copy))
 => #(0 0), #(0 1)
 "

--- a/package.lisp
+++ b/package.lisp
@@ -6,5 +6,5 @@
    #:make-disjoint-sets
    #:disjoint-sets-add
    #:disjoint-sets-find
-   #:disjoint-sets-union
+   #:disjoint-sets-join
    #:disjoint-sets-same-set-p))

--- a/tests.lisp
+++ b/tests.lisp
@@ -31,20 +31,20 @@
         (list (disjoint-sets-add sets)
               sets))))
 
-(define-test disjoint-set-union
+(define-test disjoint-set-join
   (is equalp
       #(0 1 1 3 4 5 6 7 8 1)
       (let ((sets (make-disjoint-sets 10)))
-        (disjoint-sets-union sets 1 2)
-        (disjoint-sets-union sets 1 9)
+        (disjoint-sets-join sets 1 2)
+        (disjoint-sets-join sets 1 9)
         sets)))
 
 (define-test disjoint-set-same-set-p
   (is equalp
       '(t t nil)
       (let ((sets (make-disjoint-sets 10)))
-        (disjoint-sets-union sets 1 2)
-        (disjoint-sets-union sets 1 9)
+        (disjoint-sets-join sets 1 2)
+        (disjoint-sets-join sets 1 9)
         (list (disjoint-sets-same-set-p sets 1 2)
               (disjoint-sets-same-set-p sets 2 9)
               (disjoint-sets-same-set-p sets 1 5)))))


### PR DESCRIPTION
This separate Pull Request is for changes you might not want to accept. One commit is some slight rewrites of things that bugged me in the source code, although they are subjective; the other is a breaking change that renames `disjoint-sets-union` to `disjoint-sets-unify`. I think it is confusing to experienced CL programmers, familiar with `cl:union` behaving non-destructively, that a function whose name includes "union" would modify its argument. It might be preferable to name it like `cl:nunion`, the destructive variant; however I think these are sufficiently different that it is better to use separate nomenclature.